### PR TITLE
Update getTrailers.js

### DIFF
--- a/src/js/getTrailers.js
+++ b/src/js/getTrailers.js
@@ -27,6 +27,7 @@ export async function renderTrailersBtns(trailers) {
   }
   const markup = trailers
     .slice(0, 3)
+    .reverse()
     .map(trailer => {
       let name = trailer.name;
       if (trailer.name.length > 30) {


### PR DESCRIPTION
Розвернув масив таким чином, що не було спочатку "трейлер 1", а потім "трейлер 3". Тепер все гарно. Трейлери відмальовуються в хронологічному порядку