### PR TITLE
Update getTrailers.js

### DIFF
--- a/src/js/getTrailers.js
+++ b/src/js/getTrailers.js
@@ -26,7 +26,7 @@ export async function renderTrailersBtns(trailers) {
     trailersHeader.classList.add('visually-hidden__title');
   }
   const markup = trailers
-    .slice(0, 3)
+    .slice(0, 4)
     .reverse()
     .map(trailer => {
       let name = trailer.name;


### PR DESCRIPTION
Враховуючі що кнопка третього трейлеру все одно переноситься на наступний рядок, я вирішив, що там де є 4 трейлера може показуватись 4 трейлера без шкоди для інтерфейсу. Коротше, тепер може показуватись до чотирьох трейлерів
![image](https://user-images.githubusercontent.com/41117606/213871922-05bdf007-9e22-4ee9-818e-7961a26f0fca.png)
